### PR TITLE
allow self-signed SSL certificate in phantomjs options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,11 @@ In case local web site is served by nginx or Apache, and is configured for a spe
 ```
 docker run -i -t -p 4444:4444 -e APP_HOST=myapp davert/phantomjs-env 
 ```
+
+### Accessing Site with self-signed certificate
+
+If you want to test site in local environment without proper SSL certificate, you can pass APP_ANY_PROTOCOL setting as environment variable:
+
+```
+docker run -i -t -p 4444:4444 -e APP_ANY_PROTOCOL=true davert/phantomjs-env 
+```

--- a/start.sh
+++ b/start.sh
@@ -10,10 +10,18 @@ echo "Host IP: $HOST_IP"
 echo "$HOST_IP dockerhost" >> /etc/hosts
 
 # adding APP_HOST to list of known hosts
-if [ $APP_HOST ]; 
-then 
+if [ $APP_HOST ];
+then
   echo "Registering host $APP_HOST"
   echo "$HOSTIP $APP_HOST" >> /etc/hosts
+fi;
+
+# allow for running in test environment
+if [ $APP_ANY_PROTOCOL ];
+then
+  UNTRUSTED_COMMAND="--ignore-ssl-errors=true --ssl-protocol=any"
+else
+  UNTRUSTED_COMMAND=""
 fi;
 
 # if only port provided - redirect to host+port
@@ -24,4 +32,4 @@ then
 fi;
 
 # starting selenium
-phantomjs --webdriver=4444
+phantomjs --webdriver=4444 $UNTRUSTED_COMMAND


### PR DESCRIPTION
While creating new container one can use options that allows for running on local websites and https protocol:
`
docker run -i -t -p 4444:4444 -e APP_ANY_PROTOCOL=true davert/phantomjs-env
`
will run phantomjs with those options:
`
phantomjs --webdriver=4444  --ignore-ssl-errors=true --ssl-protocol=any
`
